### PR TITLE
fix: avoid weakref for Updater cleanup callback

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -9,7 +9,6 @@ import tempfile
 import hashlib
 from typing import Dict, Any, List
 from pathlib import Path
-from weakref import WeakKeyDictionary
 
 from telegram import (
     Update,
@@ -43,7 +42,8 @@ except Exception:
 from telegram.ext import _updater as _ptb_updater
 
 if not hasattr(_ptb_updater.Updater, "_Updater__polling_cleanup_cb"):
-    _cb_store: "WeakKeyDictionary[_ptb_updater.Updater, Any]" = WeakKeyDictionary()
+    # Updater doesn't support weak references, so store callbacks in a plain dict.
+    _cb_store: "Dict[_ptb_updater.Updater, Any]" = {}
 
     class _CleanupCbDescriptor:
         def __get__(self, instance, owner):  # type: ignore[override]


### PR DESCRIPTION
## Summary
- fallback to a plain dict for the `_polling_cleanup_cb` descriptor because `Updater` cannot be weak-referenced on Python 3.13

## Testing
- `pre-commit run --files bot/main.py`
- `python -m py_compile bot/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb07f46ea4832292bdcd692fb8751d