### PR TITLE
Handle scraper failures and refresh headers

### DIFF
--- a/jobspy/__init__.py
+++ b/jobspy/__init__.py
@@ -113,9 +113,15 @@ def scrape_jobs(
 
     site_to_jobs_dict = {}
 
-    def worker(site):
-        site_val, scraped_info = scrape_site(site)
-        return site_val, scraped_info
+    def worker(site: Site) -> Tuple[str, JobResponse]:
+        try:
+            return scrape_site(site)
+        except Exception as e:
+            cap_name = site.value.capitalize()
+            site_name = "ZipRecruiter" if cap_name == "Zip_recruiter" else cap_name
+            site_name = "LinkedIn" if cap_name == "Linkedin" else cap_name
+            create_logger(site_name).error(f"scrape failed: {e}")
+            return site.value, JobResponse(jobs=[])
 
     with ThreadPoolExecutor() as executor:
         future_to_site = {

--- a/jobspy/bayt/__init__.py
+++ b/jobspy/bayt/__init__.py
@@ -31,12 +31,18 @@ class BaytScraper(Scraper):
         self.scraper_input = None
         self.session = None
         self.country = "worldwide"
+        self.user_agent = user_agent
 
     def scrape(self, scraper_input: ScraperInput) -> JobResponse:
         self.scraper_input = scraper_input
         self.session = create_session(
             proxies=self.proxies, ca_cert=self.ca_cert, is_tls=False, has_retry=True
         )
+        ua = self.user_agent or (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+        )
+        self.session.headers.update({"user-agent": ua})
         job_list: list[JobPost] = []
         page = 1
         results_wanted = (

--- a/jobspy/ziprecruiter/__init__.py
+++ b/jobspy/ziprecruiter/__init__.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from bs4 import BeautifulSoup
 
-from jobspy.ziprecruiter.constant import headers, get_cookie_data
+from jobspy.ziprecruiter.constant import build_headers, get_cookie_data
 from jobspy.util import (
     extract_emails_from_text,
     create_session,
@@ -47,7 +47,7 @@ class ZipRecruiter(Scraper):
 
         self.scraper_input = None
         self.session = create_session(proxies=proxies, ca_cert=ca_cert)
-        self.session.headers.update(headers)
+        self.session.headers.update(build_headers())
         self._get_cookies()
 
         self.delay = 5
@@ -216,4 +216,4 @@ class ZipRecruiter(Scraper):
         Sends a session event to the API with device properties.
         """
         url = f"{self.api_url}/jobs-app/event"
-        self.session.post(url, data=get_cookie_data)
+        self.session.post(url, data=get_cookie_data())

--- a/jobspy/ziprecruiter/constant.py
+++ b/jobspy/ziprecruiter/constant.py
@@ -1,29 +1,43 @@
-headers = {
-    "Host": "api.ziprecruiter.com",
-    "accept": "*/*",
-    "x-zr-zva-override": "100000000;vid:ZT1huzm_EQlDTVEc",
-    "x-pushnotificationid": "0ff4983d38d7fc5b3370297f2bcffcf4b3321c418f5c22dd152a0264707602a0",
-    "x-deviceid": "D77B3A92-E589-46A4-8A39-6EF6F1D86006",
-    "user-agent": "Job Search/87.0 (iPhone; CPU iOS 16_6_1 like Mac OS X)",
-    "authorization": "Basic YTBlZjMyZDYtN2I0Yy00MWVkLWEyODMtYTI1NDAzMzI0YTcyOg==",
-    "accept-language": "en-US,en;q=0.9",
-}
+from __future__ import annotations
 
-get_cookie_data = [
-    ("event_type", "session"),
-    ("logged_in", "false"),
-    ("number_of_retry", "1"),
-    ("property", "model:iPhone"),
-    ("property", "os:iOS"),
-    ("property", "locale:en_us"),
-    ("property", "app_build_number:4734"),
-    ("property", "app_version:91.0"),
-    ("property", "manufacturer:Apple"),
-    ("property", "timestamp:2025-01-12T12:04:42-06:00"),
-    ("property", "screen_height:852"),
-    ("property", "os_version:16.6.1"),
-    ("property", "source:install"),
-    ("property", "screen_width:393"),
-    ("property", "device_model:iPhone 14 Pro"),
-    ("property", "brand:Apple"),
-]
+import uuid
+from datetime import datetime
+
+
+def build_headers() -> dict[str, str]:
+    """Create ZipRecruiter headers with randomized identifiers."""
+    return {
+        "Host": "api.ziprecruiter.com",
+        "accept": "*/*",
+        "x-zr-zva-override": "100000000;vid:ZT1huzm_EQlDTVEc",
+        # Random values to look like a fresh mobile client
+        "x-pushnotificationid": uuid.uuid4().hex,
+        "x-deviceid": str(uuid.uuid4()).upper(),
+        "user-agent": "Job Search/91.0 (iPhone; CPU iOS 16_6_1 like Mac OS X)",
+        "authorization": "Basic YTBlZjMyZDYtN2I0Yy00MWVkLWEyODMtYTI1NDAzMzI0YTcyOg==",
+        "accept-language": "en-US,en;q=0.9",
+    }
+
+
+def get_cookie_data() -> list[tuple[str, str]]:
+    """Return session event data with a current timestamp."""
+    ts = datetime.utcnow().isoformat()
+    return [
+        ("event_type", "session"),
+        ("logged_in", "false"),
+        ("number_of_retry", "1"),
+        ("property", "model:iPhone"),
+        ("property", "os:iOS"),
+        ("property", "locale:en_us"),
+        ("property", "app_build_number:4734"),
+        ("property", "app_version:91.0"),
+        ("property", "manufacturer:Apple"),
+        ("property", f"timestamp:{ts}"),
+        ("property", "screen_height:852"),
+        ("property", "os_version:16.6.1"),
+        ("property", "source:install"),
+        ("property", "screen_width:393"),
+        ("property", "device_model:iPhone 14 Pro"),
+        ("property", "brand:Apple"),
+    ]
+


### PR DESCRIPTION
## Summary
- prevent individual scraper failures from stopping JobSpy
- refresh ZipRecruiter headers and cookie data
- supply a browser User-Agent for Bayt requests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb1af5c7388322923753e9f95880d7