### PR TITLE
feat: refresh ZipRecruiter session on 403 errors

### DIFF
--- a/jobspy/ziprecruiter/constant.py
+++ b/jobspy/ziprecruiter/constant.py
@@ -1,15 +1,28 @@
 from __future__ import annotations
 
+import secrets
 import uuid
 from datetime import datetime
 
 
 def build_headers() -> dict[str, str]:
-    """Create ZipRecruiter headers with randomized identifiers."""
+    """Create ZipRecruiter headers with randomized identifiers.
+
+    The ZipRecruiter API is fronted by Cloudflare's WAF. Reusing
+    identifiers such as the ``vid`` token can quickly lead to requests
+    being blocked with ``forbidden cf-waf`` responses. Generating a fresh
+    random token for each session helps mimic legitimate mobile clients
+    and reduces the chance of triggering Cloudflare defenses.
+    """
+
+    # ``vid`` has historically been a random URL safe string. Generate a
+    # new one for every session to appear as a unique device.
+    vid = secrets.token_urlsafe(8)
+
     return {
         "Host": "api.ziprecruiter.com",
         "accept": "*/*",
-        "x-zr-zva-override": "100000000;vid:ZT1huzm_EQlDTVEc",
+        "x-zr-zva-override": f"100000000;vid:{vid}",
         # Random values to look like a fresh mobile client
         "x-pushnotificationid": uuid.uuid4().hex,
         "x-deviceid": str(uuid.uuid4()).upper(),


### PR DESCRIPTION
## Summary
- randomize ZipRecruiter vid header to evade Cloudflare WAF
- retry ZipRecruiter requests with fresh headers/cookies when 403 is received

## Testing
- `python -m py_compile jobspy/ziprecruiter/constant.py jobspy/ziprecruiter/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb1eb7b94c832284d5ddf4f8448c63