### PR TITLE
Handle missing Glassdoor pagination cursors

### DIFF
--- a/jobspy/glassdoor/util.py
+++ b/jobspy/glassdoor/util.py
@@ -37,6 +37,9 @@ def parse_location(location_name: str) -> Location | None:
 
 
 def get_cursor_for_page(pagination_cursors, page_num):
+    if not pagination_cursors:
+        return None
     for cursor_data in pagination_cursors:
         if cursor_data["pageNumber"] == page_num:
             return cursor_data["cursor"]
+    return None


### PR DESCRIPTION
## Summary
- avoid iterating over missing pagination cursor lists in Glassdoor scraper

## Testing
- `python -m pytest`
- `python -m py_compile jobspy/glassdoor/util.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb2d92e6f88322aaca58a474f0a8b1