### PR TITLE
Mitigate ZipRecruiter 403 errors by rotating request identifiers

### DIFF
--- a/jobspy/ziprecruiter/__init__.py
+++ b/jobspy/ziprecruiter/__init__.py
@@ -117,6 +117,14 @@ class ZipRecruiter(Scraper):
         if continue_token:
             params["continue_from"] = continue_token
 
+        # Rotate headers and cookie identifiers for every page request to
+        # emulate a fresh mobile client on each call. Reusing identifiers
+        # like the ``vid`` token too many times can trigger Cloudflare's
+        # ``forbidden cf-waf`` response even if individual requests are
+        # spaced out.
+        self.session.headers.update(build_headers())
+        self._get_cookies()
+
         last_error: str | None = None
         for attempt in range(self.max_retries):
             try:


### PR DESCRIPTION
## Summary
- Rotate headers and cookie identifiers for every ZipRecruiter page request to mimic fresh mobile clients

## Testing
- `pre-commit run --files jobspy/ziprecruiter/__init__.py`
- `python - <<'PY' ...` *(fails: connect: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb331c3ef08322aa750426a88d5d57