### PR TITLE
Limit vacancy fetch timeout to 3 seconds

### DIFF
--- a/jobspy/__init__.py
+++ b/jobspy/__init__.py
@@ -28,6 +28,7 @@ from jobspy.ziprecruiter import ZipRecruiter
 
 # Update the SCRAPER_MAPPING dictionary in the scrape_jobs function
 
+
 def scrape_jobs(
     site_name: str | list[str] | Site | list[Site] | None = None,
     search_term: str | None = None,
@@ -49,6 +50,7 @@ def scrape_jobs(
     enforce_annual_salary: bool = False,
     verbose: int = 0,
     user_agent: str = None,
+    request_timeout: int = 3,
     **kwargs,
 ) -> pd.DataFrame:
     """
@@ -99,6 +101,7 @@ def scrape_jobs(
         linkedin_company_ids=linkedin_company_ids,
         offset=offset,
         hours_old=hours_old,
+        request_timeout=request_timeout,
     )
 
     def scrape_site(site: Site) -> Tuple[str, JobResponse]:
@@ -191,7 +194,7 @@ def scrape_jobs(
                 else None
             )
 
-            #naukri-specific fields
+            # naukri-specific fields
             job_data["skills"] = (
                 ", ".join(job_data["skills"]) if job_data["skills"] else None
             )

--- a/jobspy/bayt/__init__.py
+++ b/jobspy/bayt/__init__.py
@@ -25,7 +25,10 @@ class BaytScraper(Scraper):
     band_delay = 3
 
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None
+        self,
+        proxies: list[str] | str | None = None,
+        ca_cert: str | None = None,
+        user_agent: str | None = None,
     ):
         super().__init__(Site.BAYT, proxies=proxies, ca_cert=ca_cert)
         self.scraper_input = None
@@ -93,7 +96,10 @@ class BaytScraper(Scraper):
         """
         try:
             url = f"{self.base_url}/en/international/jobs/{query}-jobs/?page={page}"
-            response = self.session.get(url)
+            response = self.session.get(
+                url,
+                timeout=getattr(self.scraper_input, "request_timeout", 60),
+            )
             response.raise_for_status()
             soup = BeautifulSoup(response.text, "html.parser")
             job_listings = soup.find_all("li", attrs={"data-js-job": ""})

--- a/jobspy/bdjobs/__init__.py
+++ b/jobspy/bdjobs/__init__.py
@@ -255,7 +255,10 @@ class BDJobs(Scraper):
         :return: Dictionary with job details
         """
         try:
-            response = self.session.get(job_url, timeout=60)
+            response = self.session.get(
+                job_url,
+                timeout=getattr(self.scraper_input, "request_timeout", 60),
+            )
             if response.status_code != 200:
                 return {}
 

--- a/jobspy/glassdoor/__init__.py
+++ b/jobspy/glassdoor/__init__.py
@@ -34,7 +34,10 @@ log = create_logger("Glassdoor")
 
 class Glassdoor(Scraper):
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None
+        self,
+        proxies: list[str] | str | None = None,
+        ca_cert: str | None = None,
+        user_agent: str | None = None,
     ):
         """
         Initializes GlassdoorScraper with the Glassdoor job search url
@@ -113,7 +116,7 @@ class Glassdoor(Scraper):
             payload = self._add_payload(location_id, location_type, page_num, cursor)
             response = self.session.post(
                 f"{self.base_url}/graph",
-                timeout_seconds=15,
+                timeout_seconds=getattr(self.scraper_input, "request_timeout", 60),
                 data=payload,
             )
             if response.status_code != 200:
@@ -153,7 +156,10 @@ class Glassdoor(Scraper):
         """
         Fetches csrf token needed for API by visiting a generic page
         """
-        res = self.session.get(f"{self.base_url}/Job/computer-science-jobs.htm")
+        res = self.session.get(
+            f"{self.base_url}/Job/computer-science-jobs.htm",
+            timeout_seconds=getattr(self.scraper_input, "request_timeout", 60),
+        )
         pattern = r'"token":\s*"([^"]+)"'
         matches = re.findall(pattern, res.text)
         token = None
@@ -259,7 +265,10 @@ class Glassdoor(Scraper):
         if not location or is_remote:
             return "11047", "STATE"  # remote options
         url = f"{self.base_url}/findPopularLocationAjax.htm?maxLocationsToReturn=10&term={location}"
-        res = self.session.get(url)
+        res = self.session.get(
+            url,
+            timeout_seconds=getattr(self.scraper_input, "request_timeout", 60),
+        )
         if res.status_code != 200:
             if res.status_code == 429:
                 err = f"429 Response - Blocked by Glassdoor for too many requests"

--- a/jobspy/google/__init__.py
+++ b/jobspy/google/__init__.py
@@ -24,7 +24,10 @@ from jobspy.google.util import log, find_job_info_initial_page, find_job_info
 
 class Google(Scraper):
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None
+        self,
+        proxies: list[str] | str | None = None,
+        ca_cert: str | None = None,
+        user_agent: str | None = None,
     ):
         """
         Initializes Google Scraper with the Goodle jobs search url
@@ -130,7 +133,12 @@ class Google(Scraper):
         params = {"q": query, "udm": "8"}
         for attempt in range(2):
             try:
-                response = self.session.get(self.url, headers=headers_initial, params=params)
+                response = self.session.get(
+                    self.url,
+                    headers=headers_initial,
+                    params=params,
+                    timeout=getattr(self.scraper_input, "request_timeout", 60),
+                )
                 break
             except requests.exceptions.RetryError:
                 log.warning(
@@ -157,7 +165,10 @@ class Google(Scraper):
         for attempt in range(2):
             try:
                 response = self.session.get(
-                    self.jobs_url, headers=headers_jobs, params=params
+                    self.jobs_url,
+                    headers=headers_jobs,
+                    params=params,
+                    timeout=getattr(self.scraper_input, "request_timeout", 60),
                 )
                 break
             except requests.exceptions.RetryError:

--- a/jobspy/indeed/__init__.py
+++ b/jobspy/indeed/__init__.py
@@ -28,7 +28,10 @@ log = create_logger("Indeed")
 
 class Indeed(Scraper):
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None
+        self,
+        proxies: list[str] | str | None = None,
+        ca_cert: str | None = None,
+        user_agent: str | None = None,
     ):
         """
         Initializes IndeedScraper with the Indeed API url
@@ -114,7 +117,7 @@ class Indeed(Scraper):
             self.api_url,
             headers=api_headers_temp,
             json=payload,
-            timeout=10,
+            timeout=getattr(self.scraper_input, "request_timeout", 60),
             verify=False,
         )
         if not response.ok:

--- a/jobspy/linkedin/__init__.py
+++ b/jobspy/linkedin/__init__.py
@@ -18,7 +18,7 @@ from jobspy.linkedin.util import (
     job_type_code,
     parse_job_type,
     parse_job_level,
-    parse_company_industry
+    parse_company_industry,
 )
 from jobspy.model import (
     JobPost,
@@ -51,7 +51,10 @@ class LinkedIn(Scraper):
     jobs_per_page = 25
 
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None
+        self,
+        proxies: list[str] | str | None = None,
+        ca_cert: str | None = None,
+        user_agent: str | None = None,
     ):
         """
         Initializes LinkedInScraper with the LinkedIn job search url
@@ -119,7 +122,7 @@ class LinkedIn(Scraper):
                 response = self.session.get(
                     f"{self.base_url}/jobs-guest/jobs/api/seeMoreJobPostings/search?",
                     params=params,
-                    timeout=10,
+                    timeout=getattr(self.scraper_input, "request_timeout", 60),
                 )
                 if response.status_code not in range(200, 400):
                     if response.status_code == 429:
@@ -250,7 +253,8 @@ class LinkedIn(Scraper):
         """
         try:
             response = self.session.get(
-                f"{self.base_url}/jobs/view/{job_id}", timeout=5
+                f"{self.base_url}/jobs/view/{job_id}",
+                timeout=getattr(self.scraper_input, "request_timeout", 60),
             )
             response.raise_for_status()
         except:

--- a/jobspy/model.py
+++ b/jobspy/model.py
@@ -236,6 +236,7 @@ class DescriptionFormat(Enum):
     HTML = "html"
     PLAIN = "plain"
 
+
 class JobPost(BaseModel):
     id: str | None = None
     title: str
@@ -273,12 +274,15 @@ class JobPost(BaseModel):
     job_function: str | None = None
 
     # Naukri specific
-    skills: list[str] | None = None  #from tagsAndSkills
-    experience_range: str | None = None  #from experienceText
-    company_rating: float | None = None  #from ambitionBoxData.AggregateRating
-    company_reviews_count: int | None = None  #from ambitionBoxData.ReviewsCount
-    vacancy_count: int | None = None  #from vacancy
-    work_from_home_type: str | None = None  #from clusters.wfhType (e.g., "Hybrid", "Remote")
+    skills: list[str] | None = None  # from tagsAndSkills
+    experience_range: str | None = None  # from experienceText
+    company_rating: float | None = None  # from ambitionBoxData.AggregateRating
+    company_reviews_count: int | None = None  # from ambitionBoxData.ReviewsCount
+    vacancy_count: int | None = None  # from vacancy
+    work_from_home_type: str | None = (
+        None  # from clusters.wfhType (e.g., "Hybrid", "Remote")
+    )
+
 
 class JobResponse(BaseModel):
     jobs: list[JobPost] = []
@@ -316,7 +320,7 @@ class ScraperInput(BaseModel):
     linkedin_company_ids: list[int] | None = None
     description_format: DescriptionFormat | None = DescriptionFormat.MARKDOWN
 
-    request_timeout: int = 60
+    request_timeout: int = 3
 
     results_wanted: int = 15
     hours_old: int | None = None
@@ -324,7 +328,11 @@ class ScraperInput(BaseModel):
 
 class Scraper(ABC):
     def __init__(
-        self, site: Site, proxies: list[str] | None = None, ca_cert: str | None = None, user_agent: str | None = None
+        self,
+        site: Site,
+        proxies: list[str] | None = None,
+        ca_cert: str | None = None,
+        user_agent: str | None = None,
     ):
         self.site = site
         self.proxies = proxies

--- a/jobspy/naukri/__init__.py
+++ b/jobspy/naukri/__init__.py
@@ -37,14 +37,18 @@ from jobspy.util import (
 
 log = create_logger("Naukri")
 
+
 class Naukri(Scraper):
     base_url = "https://www.naukri.com/jobapi/v3/search"
     delay = 3
     band_delay = 4
-    jobs_per_page = 20  
+    jobs_per_page = 20
 
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None
+        self,
+        proxies: list[str] | str | None = None,
+        ca_cert: str | None = None,
+        user_agent: str | None = None,
     ):
         """
         Initializes NaukriScraper with the Naukri API URL
@@ -60,7 +64,7 @@ class Naukri(Scraper):
         )
         self.session.headers.update(naukri_headers)
         self.scraper_input = None
-        self.country = "India"  #naukri is india-focused by default
+        self.country = "India"  # naukri is india-focused by default
         log.info("Naukri scraper initialized")
 
     def scrape(self, scraper_input: ScraperInput) -> JobResponse:
@@ -79,7 +83,8 @@ class Naukri(Scraper):
             scraper_input.hours_old * 3600 if scraper_input.hours_old else None
         )
         continue_search = (
-            lambda: len(job_list) < scraper_input.results_wanted and page <= 50  # Arbitrary limit
+            lambda: len(job_list) < scraper_input.results_wanted
+            and page <= 50  # Arbitrary limit
         )
 
         while continue_search():
@@ -107,7 +112,11 @@ class Naukri(Scraper):
             params = {k: v for k, v in params.items() if v is not None}
             try:
                 log.debug(f"Sending request to {self.base_url} with params: {params}")
-                response = self.session.get(self.base_url, params=params, timeout=10)
+                response = self.session.get(
+                    self.base_url,
+                    params=params,
+                    timeout=getattr(self.scraper_input, "request_timeout", 60),
+                )
                 if response.status_code not in range(200, 400):
                     err = f"Naukri API response status code {response.status_code} - {response.text}"
                     log.error(err)
@@ -145,7 +154,7 @@ class Naukri(Scraper):
                 time.sleep(random.uniform(self.delay, self.delay + self.band_delay))
                 page += 1
 
-        job_list = job_list[:scraper_input.results_wanted]
+        job_list = job_list[: scraper_input.results_wanted]
         log.info(f"Scraping completed. Total jobs collected: {len(job_list)}")
         return JobResponse(jobs=job_list)
 
@@ -157,33 +166,54 @@ class Naukri(Scraper):
         """
         title = job.get("title", "N/A")
         company = job.get("companyName", "N/A")
-        company_url = f"https://www.naukri.com/{job.get('staticUrl', '')}" if job.get("staticUrl") else None
+        company_url = (
+            f"https://www.naukri.com/{job.get('staticUrl', '')}"
+            if job.get("staticUrl")
+            else None
+        )
 
         location = self._get_location(job.get("placeholders", []))
         compensation = self._get_compensation(job.get("placeholders", []))
-        date_posted = self._parse_date(job.get("footerPlaceholderLabel"), job.get("createdDate"))
+        date_posted = self._parse_date(
+            job.get("footerPlaceholderLabel"), job.get("createdDate")
+        )
 
         job_url = f"https://www.naukri.com{job.get('jdURL', f'/job/{job_id}')}"
         raw_description = job.get("jobDescription") if full_descr else None
 
         job_type = parse_job_type(raw_description) if raw_description else None
-        company_industry = parse_company_industry(raw_description) if raw_description else None
+        company_industry = (
+            parse_company_industry(raw_description) if raw_description else None
+        )
 
         description = raw_description
-        if description and self.scraper_input.description_format == DescriptionFormat.MARKDOWN:
+        if (
+            description
+            and self.scraper_input.description_format == DescriptionFormat.MARKDOWN
+        ):
             description = markdown_converter(description)
 
         is_remote = is_job_remote(title, description or "", location)
         company_logo = job.get("logoPathV3") or job.get("logoPath")
 
         # Naukri-specific fields
-        skills = job.get("tagsAndSkills", "").split(",") if job.get("tagsAndSkills") else None
+        skills = (
+            job.get("tagsAndSkills", "").split(",")
+            if job.get("tagsAndSkills")
+            else None
+        )
         experience_range = job.get("experienceText")
         ambition_box = job.get("ambitionBoxData", {})
-        company_rating = float(ambition_box.get("AggregateRating")) if ambition_box.get("AggregateRating") else None
+        company_rating = (
+            float(ambition_box.get("AggregateRating"))
+            if ambition_box.get("AggregateRating")
+            else None
+        )
         company_reviews_count = ambition_box.get("ReviewsCount")
         vacancy_count = job.get("vacancy")
-        work_from_home_type = self._infer_work_from_home_type(job.get("placeholders", []), title, description or "")
+        work_from_home_type = self._infer_work_from_home_type(
+            job.get("placeholders", []), title, description or ""
+        )
 
         job_post = JobPost(
             id=f"nk-{job_id}",
@@ -238,7 +268,11 @@ class Naukri(Scraper):
                     return None
 
                 # Handle Indian salary formats (e.g., "12-16 Lacs P.A.", "1-5 Cr")
-                salary_match = re.match(r"(\d+(?:\.\d+)?)\s*-\s*(\d+(?:\.\d+)?)\s*(Lacs|Lakh|Cr)\s*(P\.A\.)?", salary_text, re.IGNORECASE)
+                salary_match = re.match(
+                    r"(\d+(?:\.\d+)?)\s*-\s*(\d+(?:\.\d+)?)\s*(Lacs|Lakh|Cr)\s*(P\.A\.)?",
+                    salary_text,
+                    re.IGNORECASE,
+                )
                 if salary_match:
                     min_salary, max_salary, unit = salary_match.groups()[:3]
                     min_salary, max_salary = float(min_salary), float(max_salary)
@@ -270,7 +304,9 @@ class Naukri(Scraper):
         today = datetime.now()
         if not label:
             if created_date:
-                return datetime.fromtimestamp(created_date / 1000).date()  # Convert to date
+                return datetime.fromtimestamp(
+                    created_date / 1000
+                ).date()  # Convert to date
             return None
         label = label.lower()
         if "today" in label or "just now" in label or "few hours" in label:
@@ -280,7 +316,7 @@ class Naukri(Scraper):
             match = re.search(r"(\d+)\s*day", label)
             if match:
                 days = int(match.group(1))
-                parsed_date = (today - timedelta(days = days)).date()
+                parsed_date = (today - timedelta(days=days)).date()
                 log.debug(f"Date parsed: {days} days ago -> {parsed_date}")
                 return parsed_date
         elif created_date:
@@ -290,15 +326,29 @@ class Naukri(Scraper):
         log.debug("No date parsed")
         return None
 
-    def _infer_work_from_home_type(self, placeholders: list[dict], title: str, description: str) -> Optional[str]:
+    def _infer_work_from_home_type(
+        self, placeholders: list[dict], title: str, description: str
+    ) -> Optional[str]:
         """
         Infers work-from-home type from job data (e.g., 'Hybrid', 'Remote', 'Work from office')
         """
-        location_str = next((p["label"] for p in placeholders if p["type"] == "location"), "").lower()
-        if "hybrid" in location_str or "hybrid" in title.lower() or "hybrid" in description.lower():
+        location_str = next(
+            (p["label"] for p in placeholders if p["type"] == "location"), ""
+        ).lower()
+        if (
+            "hybrid" in location_str
+            or "hybrid" in title.lower()
+            or "hybrid" in description.lower()
+        ):
             return "Hybrid"
-        elif "remote" in location_str or "remote" in title.lower() or "remote" in description.lower():
+        elif (
+            "remote" in location_str
+            or "remote" in title.lower()
+            or "remote" in description.lower()
+        ):
             return "Remote"
-        elif "work from office" in description.lower() or not ("remote" in description.lower() or "hybrid" in description.lower()):
+        elif "work from office" in description.lower() or not (
+            "remote" in description.lower() or "hybrid" in description.lower()
+        ):
             return "Work from office"
         return None

--- a/jobspy/ziprecruiter/__init__.py
+++ b/jobspy/ziprecruiter/__init__.py
@@ -129,7 +129,11 @@ class ZipRecruiter(Scraper):
         last_error: str | None = None
         for attempt in range(self.max_retries):
             try:
-                res = self.session.get(f"{self.api_url}/jobs-app/jobs", params=params)
+                res = self.session.get(
+                    f"{self.api_url}/jobs-app/jobs",
+                    params=params,
+                    timeout_seconds=getattr(self.scraper_input, "request_timeout", 60),
+                )
             except Exception as e:
                 last_error = str(e)
                 if "Proxy responded with" in last_error:
@@ -246,7 +250,11 @@ class ZipRecruiter(Scraper):
         )
 
     def _get_descr(self, job_url):
-        res = self.session.get(job_url, allow_redirects=True)
+        res = self.session.get(
+            job_url,
+            allow_redirects=True,
+            timeout_seconds=getattr(self.scraper_input, "request_timeout", 60),
+        )
         description_full = job_url_direct = None
         if res.ok:
             soup = BeautifulSoup(res.text, "html.parser")
@@ -289,7 +297,11 @@ class ZipRecruiter(Scraper):
         last_error: str | None = None
         for attempt in range(self.max_retries):
             try:
-                res = self.session.post(url, data=data)
+                res = self.session.post(
+                    url,
+                    data=data,
+                    timeout_seconds=getattr(self.scraper_input, "request_timeout", 60),
+                )
             except Exception as e:
                 last_error = str(e)
             else:


### PR DESCRIPTION
## Summary
- cap job vacancy search to 3 seconds
- propagate timeout to all job board scrapers

## Testing
- `pre-commit run --files bot/jobs.py jobspy/__init__.py jobspy/bayt/__init__.py jobspy/bdjobs/__init__.py jobspy/glassdoor/__init__.py jobspy/google/__init__.py jobspy/indeed/__init__.py jobspy/linkedin/__init__.py jobspy/model.py jobspy/naukri/__init__.py jobspy/ziprecruiter/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb3e0c1f708322b2379b18628f1885