### PR TITLE
Add global scrape timeout for faster job searches

### DIFF
--- a/bot/jobs.py
+++ b/bot/jobs.py
@@ -110,6 +110,7 @@ def search_jobs(
             enforce_annual_salary=True,
             verbose=0,
             request_timeout=3,
+            scrape_timeout=5,
         )
     except Exception as e:
         raise RuntimeError(f"JobSpy search failed: {e}")


### PR DESCRIPTION
## Summary
- add optional `scrape_timeout` parameter in JobSpy to stop waiting on slow sources
- use `scrape_timeout=5` in bot's `search_jobs` to enforce a 5-second cap

## Testing
- `pytest -q`
- `python -m py_compile jobspy/__init__.py bot/jobs.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb439e65308322b888c4e64d9faea3