### PR TITLE
Increase scrape timeout for job searches

### DIFF
--- a/bot/jobs.py
+++ b/bot/jobs.py
@@ -17,6 +17,9 @@ DEFAULT_SOURCES = [
     "glassdoor",
 ]
 
+# Allow more time for slower job sites before abandoning results
+SCRAPE_TIMEOUT = 15
+
 
 def _str_clean(v: Any) -> str:
     """Return safe string. Treat None/NaN as empty string; cast others to str."""
@@ -110,7 +113,7 @@ def search_jobs(
             enforce_annual_salary=True,
             verbose=0,
             request_timeout=3,
-            scrape_timeout=5,
+            scrape_timeout=SCRAPE_TIMEOUT,
         )
     except Exception as e:
         raise RuntimeError(f"JobSpy search failed: {e}")


### PR DESCRIPTION
## Summary
- extend global scrape timeout to 15s to reduce incomplete results from slow sites

## Testing
- `pre-commit run --files bot/jobs.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb48244b3c8322b83fa0493b9c2b0a