### PR TITLE
chore: add typescript dev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.pyc
 .env
 dist
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "microstudio-job-search-bot",
+  "version": "1.0.0",
+  "private": true,
+  "devDependencies": {
+    "typescript": "^5.9.2"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+
+packages:
+
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  typescript@5.9.2: {}


### PR DESCRIPTION
## Summary
- add TypeScript as a dev dependency
- ignore `node_modules`

## Testing
- `pre-commit run --files .gitignore package.json pnpm-lock.yaml`
- `pnpm exec tsc --version`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be58f356e88322a669799c088edad4